### PR TITLE
docs: adds GH issue templates and contribution guidelines.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,30 @@
+---
+name: "🐛 Bug report"
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.:bug: 
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Device / system:**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,17 @@
+---
+name: "💡 Feature request"
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Closes #000 (replace with the issue ID(s) of any related issues that will be closed when this PR is merged)
+
+**Description**
+What does this PR do or fix?
+
+**Checklist**
+Indicate what checks or tests you have completed here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+We welcome all forms of contribution! Feedback, [bug reports](https://github.com/buildit/gravity-particles/issues/new?template=bug-report.md) and [feature requests](https://github.com/buildit/gravity-particles/issues/new?template=feature-request.md) can be just as valuable as code contributions!
+
+If you want to make code contributions, please follow the process outlined below. Whether you have a specific fix or feature in mind already, or if you have spare time and just want to help out - we'd love to hear from you!
+
+
+## Code contributions
+
+### Process
+
+To avoid wasted effort, please always follow this process:
+
+1. **Reach out to the [Gravity maintainers](https://github.com/orgs/buildit/teams/gravity-maintainers)** to discuss what you want to do.
+    * This helps avoid duplicate work - someone else might already be working on the same thing you were going to do!
+    * The maintainers can also help you determine how best to architect your contribution
+1. **Create a feature branch**
+    * As per our [branching strategy](./docs/branching-strategy.md)
+1. **Write your code**
+    * Make sure you follow all the relevant conventions (see next section)
+1. **[Create a pull request](https://github.com/buildit/gravity-particles/pulls)** once your code is ready
+    * The maintainers will then review your code and, if necessary, request changes
+    * Once approved, your PR will be merged and the associated feature branch will be deleted.
+
+
+### Code conventions and other important info
+
+Before diving into the code, please familiarise yourself with the following:
+
+* Our [branching strategy](./docs/branching-strategy.md)
+
+Any code contributions that do not follow these conventions is likely to be rejected!

--- a/docs/branching-strategy.md
+++ b/docs/branching-strategy.md
@@ -1,0 +1,26 @@
+# Braching strategy
+
+This project currently uses a simple branching strategy that is inspired by [git-flow](http://nvie.com/posts/a-successful-git-branching-model/). _Diet Git Flow_, if you will.
+
+## `develop` branch
+
+The most recently delivered development changes reside in `develop`.
+
+This has been configured as a restricted branch on GitHub and only project maintainers are able to push to this branch (or merge pull requests into it).
+
+## Feature branches
+
+Contributors making changes or adding new features should always create a feature branch (with a short, descriptive [kebab-case](http://wiki.c2.com/?KebabCase) name) off of the current `HEAD` of `develop` (or off `next`, if targeting the next major release). These are short-lived branches that are deleted once the feature is complete and has been merged.
+
+**Only do one feature per branch**. If you are working on several things in parallel, create separate branches for each.
+
+Once ready for review, the feature branch should be pushed to this Github repo and a [pull request](https://help.github.com/articles/creating-a-pull-request/) should be raised.
+
+The maintainers will then review the PR and either merge into `develop` or `next` (and then delete that feature branch), or request additional changes.
+
+
+## `master` branch
+
+The `master` branch always contains the most recent _production ready_ code. 
+
+This has been configured as a restricted branch on GitHub and only project maintainers are able to push to this branch (or merge pull requests into it).

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "author": {
     "name": "Buildit",
-    "url": "http://buildit.wiprodigital.com/"
+    "url": "https://buildit.wiprodigital.com/"
   },
   "contributors": [
     "James Nash (http://cirrus.twiddles.com/)"


### PR DESCRIPTION
Closes #7 

These are pretty much copied from the `gravity-ui-web` repo.