### PR TITLE
fix: resolves issue causing warnings in build output

### DIFF
--- a/build-scripts/style-dictionary/config.js
+++ b/build-scripts/style-dictionary/config.js
@@ -22,10 +22,6 @@ module.exports = require('style-dictionary')
   .registerTransform(sdTransforms.gravitySketchColor)
   .registerTransform(sdTransforms.gravityAseColor)
   .registerTransformGroup({
-    name: 'gravity-scss',
-    transforms: ['attribute/cti', sdTransforms.gravitySassVarName.name, 'color/css']
-  })
-  .registerTransformGroup({
     name: 'gravity-ts',
     transforms: ['attribute/cti', 'name/cti/camel', 'color/css']
   })
@@ -105,7 +101,7 @@ module.exports = require('style-dictionary')
       },
       // SCSS output
       scss: {
-        transformGroup: 'gravity-scss',
+        transformGroup: 'scss',
         buildPath: `${bldApi.distPath('scss')}${path.sep}`,
         files: [
           {


### PR DESCRIPTION
**Description**
StyleDictionary was outputting warning message about duplicate token names for the SCSS output. This was because our custom naming function (which we weren't really using anymore anyway) was producing duplicate names for the color scheme input file. This change resolves the issue by reverting to SD's built-in SCSS transform group (which uses the kebab case name transform). We don't actually use the generated names anywhere in the output, so it doesn't affect the output but it stops SD showing warning messages.