### PR TITLE
feat: limits NPM package files to SASS & JS only

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "files": [
     "build-api.js",
     "build-consts.js",
-    "dist/"
+    "dist/js/",
+    "dist/scss/"
   ],
   "scripts": {
     "build": "gulp",


### PR DESCRIPTION
**Description**
Our builds now produce a number of artefacts that are not needed by web or Node.js projects that would use NPM. This PR therefore limits the files that get published to npmjs.com to just SASS & JS.

In future, we should add support for other packages or distribution mechanism for the other assets. E.g. a CocoaPod package for the Objective-C files, a JAR package for the Android XML, etc. Each of these can follow the same approach and restrict their contents to whatever files make sense for that particular platform.