### PR TITLE
fix(package): relaxes node and npm compatibility range

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
     "typescript": "^3.7.4"
   },
   "engines": {
-    "node": "^8.11.1",
-    "npm": "^5.8.0"
+    "node": ">= 8.11.1",
+    "npm": ">= 5.8.0"
   },
   "eyeglass": {
     "sassDir": "dist/scss",


### PR DESCRIPTION
Fixes an issue reported by Luciano from the Poland studios:

>Using gravity-particles with node bigger than version 8 it throws the following error error:
>```
>@buildit.candidate/gravity-particles@0.6.0: The engine "node" is incompatible with this module. Expected version "^8.11.1". Got "12.14.1"
>```

Our `engines` range for Node and NPM compatibility was too strict. Anything after Node 8.x was being considered incompatible by `npm` and would therefore display that warning menssage when you install our package.

This change relaxes the range, so all new Node (and NPM) versions, now and in the future, are considered compatible.
